### PR TITLE
商品編集機能実装

### DIFF
--- a/app/assets/javascripts/new_product.js
+++ b/app/assets/javascripts/new_product.js
@@ -30,7 +30,6 @@ $(function() {
 
   $('#image-box').on('change', '.js-file', function(e) {
     const targetIndex = $(this).parent().data('index');
-    // $('.js-file_group').eq(targetIndex).addClass('none')
     // ファイルのブラウザ上でのURLを取得
     const file = e.target.files[0];
     const blobUrl = window.URL.createObjectURL(file);
@@ -39,14 +38,15 @@ $(function() {
     if (img = $(`img[data-index="${targetIndex}"]`)[0]) {
       img.setAttribute('src', blobUrl);
     } else { //新規画像の処理
-      $('#previews').append(buildImg(targetIndex, blobUrl));
+      $('.js-file_group:last').append(buildImg(targetIndex,blobUrl));
       // fileIndexの先頭の数字を使って、inputを生成
-      $('#image-box').append(buildFileField(fileIndex[0]));
+      $('#previews').append(buildFileField(fileIndex[0]));
       fileIndex.shift();
       //末尾に１足した数を追加する
       fileIndex.push(fileIndex[fileIndex.length - 1] + 1)
     }
   });
+
 
   $('#image-box').on('click', '.js-remove', function() {
     const targetIndex = $(this).parent().data('index');
@@ -55,7 +55,7 @@ $(function() {
     //もしチェックボックスが存在すればチェックを入れる
     if (hiddenCheck) hiddenCheck.prop("checked", true);
 
-    $(this).parent().remove();
+    $(this).parent().parent().remove();
     $(`img[data-index="${targetIndex}"]`).remove();
 
     //画像入力欄が0にならないようにしておく

--- a/app/assets/javascripts/new_product.js
+++ b/app/assets/javascripts/new_product.js
@@ -47,15 +47,26 @@ $(function() {
     }
   });
 
-
+//新規投稿画像削除用
   $('#image-box').on('click', '.js-remove', function() {
+    const targetIndex = $(this).parent().data('index');
+
+    $(this).parent().parent().remove();
+    $(`img[data-index="${targetIndex}"]`).remove();
+
+    //画像入力欄が0にならないようにしておく
+    if ($('.js-file').length == 0) $('#image-box').append(buildFileField(fileIndex[0]));
+  });
+
+//編集画面画像削除用
+  $('#image-box').on('click', '.js-remove__edit', function() {
     const targetIndex = $(this).parent().data('index');
     //該当indexを振られているチェックボックスを取得
     const hiddenCheck = $(`input[data-index="${targetIndex}"].hidden-destroy`);
     //もしチェックボックスが存在すればチェックを入れる
     if (hiddenCheck) hiddenCheck.prop("checked", true);
 
-    $(this).parent().parent().remove();
+    $(this).parent().remove();
     $(`img[data-index="${targetIndex}"]`).remove();
 
     //画像入力欄が0にならないようにしておく

--- a/app/assets/stylesheets/_sell_upload_main.scss
+++ b/app/assets/stylesheets/_sell_upload_main.scss
@@ -43,7 +43,7 @@
           font-size: 12px;
         }
         &__dropbox {
-          width: 620px;
+          width: 600px;
           margin: 16px auto 0;
           border: 1px dashed #ccc;
           background: #f5f5f5;
@@ -320,21 +320,28 @@
   font-size: 14px;
 }
 
+#image-box {
+  display: flex;
+}
+
 #previews{
   display: flex;
 }
 
-  .preview{
-  display: flex;
-  position: relative;
   
- }
 
 
 .js-file_group{
+  height: 162px;
+  width: 130px;
   font-size: 14px;
   background-color: #f5f5f5;
   border: 0.5px dashed #ccc;
+  position: relative;
+}
+
+.preview{
+  padding: 10px 0 0 15px;
   position: relative;
 }
 
@@ -344,33 +351,23 @@
 //   position: relative;
 // }
 
-// .js-edit{
-//   width: 63.3px;
-//   height: 30px;
-//   text-align: center;
-//   position: absolute;
-//   bottom: 0;
-//   line-height: 30px;
-//   border: 1px solid black;
-//   background-color: skyblue;
-//   opacity: 0.5;
-// }
+.js-edit{
+  width: 60px;
+  height: 30px;
+  text-align: center;
+  position: absolute;
+  line-height: 30px;
+}
 
-// .js-remove{
-//   width: 63.3px;
-//   height: 30px;
-//   text-align: center;
-//   position: absolute;
-//   bottom: 0;
-//   left: 63.3px;
-//   line-height: 30px;
-//   border: 1px solid black;
-//   background-color: skyblue;
-//   opacity: 0.5;
-// }
+.js-remove{
+  width: 60px;
+  height: 30px;
+  text-align: center;
+  position: absolute;
+  margin-left: 40px;
+  line-height: 30px;
+}
 
-
-
-// input{
-//   display: none;
-// }
+.js-file {
+  display: none;
+}

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,4 +1,5 @@
 class ProductsController < ApplicationController
+  before_action :set_product, only:[:edit, :update, :show]
 
   def index
   end
@@ -18,19 +19,26 @@ class ProductsController < ApplicationController
   end
 
   def edit
-    @product = Product.find(params[:id])
   end
 
   def update
+      if @product.update(product_params)
+        redirect_to root_path
+      else
+        render :edit
+      end
   end
 
   def show
-    @product = Product.find(params[:id])
   end
 
   private
 
   def product_params
-    params.require(:product).permit(:name, :description, :size, :condition, :delivery_charge, :delivery_way, :prefecture_id, :delivery_days, :price, :status, product_images_attributes: [:image]).merge(user_id: current_user.id)
+    params.require(:product).permit(:name, :description, :size, :condition, :delivery_charge, :delivery_way, :prefecture_id, :delivery_days, :price, :status, product_images_attributes: [:image, :_destroy, :id]).merge(user_id: current_user.id)
+  end
+
+  def set_product
+    @product = Product.find(params[:id])
   end
 end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -17,6 +17,13 @@ class ProductsController < ApplicationController
     end
   end
 
+  def edit
+    @product = Product.find(params[:id])
+  end
+
+  def update
+  end
+
   def show
     @product = Product.find(params[:id])
   end

--- a/app/views/products/_sell_upload_main.html.haml
+++ b/app/views/products/_sell_upload_main.html.haml
@@ -14,15 +14,13 @@
           .sell-main__container__sell-form__upload-box__dropbox
             #image-box
               #previews
-                -# - if @product.persisted?
-                -#   - @product.product_images.each_with_index do |product_image, i|
-                -#     = image_tag product_image.image.url, data:{ index: i }, width: "100", height: "100"
+                - if @product.persisted?
+                  - @product.product_images.each_with_index do |product_image, i|
+                    = image_tag product_image.image.url, data:{ index: i }, width: "100", height: "100"
                 = f.fields_for :product_images do |image|
                   = image.label :image, 'ドラッグアンドドロップまたはクリックしてファイルをアップロード', class:"js-file_group", "data-index": image.index do
                     = image.file_field :image, class: "js-file"
                   - if @product.persisted?
-                    - @product.product_images.each_with_index do |product_image, i|
-                      = image_tag product_image.image.url, data:{ index: i }, class: "preview", width: "100", height: "100"
                     = image.check_box :_destroy, data:{ index: image.index }, class: "hidden-destroy"
                 - if @product.persisted?
                   %label.js-file_group{"data-index" => "#{@product.product_images.count}"}

--- a/app/views/products/_sell_upload_main.html.haml
+++ b/app/views/products/_sell_upload_main.html.haml
@@ -14,16 +14,19 @@
           .sell-main__container__sell-form__upload-box__dropbox
             #image-box
               #previews
+                -# - if @product.persisted?
+                -#   - @product.product_images.each_with_index do |product_image, i|
+                -#     = image_tag product_image.image.url, data:{ index: i }, width: "100", height: "100"
                 = f.fields_for :product_images do |image|
                   = image.label :image, 'ドラッグアンドドロップまたはクリックしてファイルをアップロード', class:"js-file_group", "data-index": image.index do
                     = image.file_field :image, class: "js-file"
                   - if @product.persisted?
                     - @product.product_images.each_with_index do |product_image, i|
-                      = image.check_box :_destroy, data:{ index: image.index }, class: "hidden-destroy"
-                      = image_tag product_image.image.url, data:{ index: i }, class: ""width: "100", height: "100"
+                      = image_tag product_image.image.url, data:{ index: i }, class: "preview", width: "100", height: "100"
+                    = image.check_box :_destroy, data:{ index: image.index }, class: "hidden-destroy"
                 - if @product.persisted?
-                  .js-file_group{"data-index" => "#{@product.product_images.count}"}
-                  = file_field_tag :image, name: "product[product_images_attributes][#{@product.product_images.count}][image]", class: "js-file"
+                  %label.js-file_group{"data-index" => "#{@product.product_images.count}"}
+                    = file_field_tag :image, name: "product[product_images_attributes][#{@product.product_images.count}][image]", class: "js-file"
       .sell-main__container__sell-form__name
         .sell-main__container__sell-form__name__form-group
           %label

--- a/app/views/products/_sell_upload_main.html.haml
+++ b/app/views/products/_sell_upload_main.html.haml
@@ -15,7 +15,7 @@
             #image-box
               #previews
                 - if @product.persisted?
-                  - @product.product_images.each_with_index do |image, i|
+                  - @product.product_images.each_with_index do |product_image, i|
                     = image_tag product_image.image.url, data:{ index: i }, width: "100", height: "100"
                 = f.fields_for :product_images do |image|
                   = image.label :image, 'ドラッグアンドドロップまたはクリックしてファイルをアップロード', class:"js-file_group", "data-index": image.index do

--- a/app/views/products/_sell_upload_main.html.haml
+++ b/app/views/products/_sell_upload_main.html.haml
@@ -14,18 +14,16 @@
           .sell-main__container__sell-form__upload-box__dropbox
             #image-box
               #previews
-                - if @product.persisted?
-                  - @product.product_images.each_with_index do |product_image, i|
-                    = image_tag product_image.image.url, data:{ index: i }, width: "100", height: "100"
                 = f.fields_for :product_images do |image|
                   = image.label :image, 'ドラッグアンドドロップまたはクリックしてファイルをアップロード', class:"js-file_group", "data-index": image.index do
                     = image.file_field :image, class: "js-file"
                   - if @product.persisted?
-                    = image.check_box :_destroy, data:{ index: image.index }, class: "hidden-destroy"
+                    - @product.product_images.each_with_index do |product_image, i|
+                      = image.check_box :_destroy, data:{ index: image.index }, class: "hidden-destroy"
+                      = image_tag product_image.image.url, data:{ index: i }, class: ""width: "100", height: "100"
                 - if @product.persisted?
                   .js-file_group{"data-index" => "#{@product.product_images.count}"}
-                    = file_field_tag :image, name: "product[product_images_attributes][#{@product.product_images.count}][image]", class: "js-file"
-                    .js-remove 削除
+                  = file_field_tag :image, name: "product[product_images_attributes][#{@product.product_images.count}][image]", class: "js-file"
       .sell-main__container__sell-form__name
         .sell-main__container__sell-form__name__form-group
           %label
@@ -48,7 +46,7 @@
               カテゴリー
               %span
                 必須
-          /= f.collection_select :upload, Upload.all, :id, :name, {prompt: '---'}, class: 'form'
+          /= f.collection_select :upload, Upload.all, :id, :name, {prompt: '---'}, class: 'form' カテゴリー機能未実装のため、コメントアウト
           .sell-main__container__sell-form__detail__box__form-group
             %label
               サイズ

--- a/app/views/products/edit.html.haml
+++ b/app/views/products/edit.html.haml
@@ -1,3 +1,138 @@
 = render partial: 'sell_upload_header'
-= render partial: 'sell_upload_main'
+.sell-main
+  .sell-main__container
+    .sell-main__container__top
+      商品の情報を入力
+    = form_for @product do |f|
+      .sell-main__container__sell-form
+        .sell-main__container__sell-form__upload-box
+          .sell-main__container__sell-form__upload-box__head
+            出品画像
+            .sell-main__container__sell-form__upload-box__require
+              必須
+          .sell-main__container__sell-form__upload-box__bottom
+            最大10枚までアップロードできます
+          .sell-main__container__sell-form__upload-box__dropbox
+            #image-box
+              #previews
+                - if @product.persisted?
+                  - @product.product_images.each_with_index do |product_image, i|
+                    = image_tag product_image.image.url, data:{ index: i }, width: "100", height: "100"
+                = f.fields_for :product_images do |image|
+                  = image.label :image, 'ドラッグアンドドロップまたはクリックしてファイルをアップロード', class:"js-file_group", "data-index": image.index do
+                    = image.file_field :image, class: "js-file"
+                    .js-remove__edit 削除
+                  - if @product.persisted?
+                    = image.check_box :_destroy, data:{ index: image.index }, class: "hidden-destroy"
+                - if @product.persisted?
+                  %label.js-file_group{"data-index" => "#{@product.product_images.count}"}
+                    = file_field_tag :image, name: "product[product_images_attributes][#{@product.product_images.count}][image]", class: "js-file"
+      .sell-main__container__sell-form__name
+        .sell-main__container__sell-form__name__form-group
+          %label
+            商品名
+            %span
+              必須
+        = f.text_field :name, placeholder: "商品名 (必須 40文字まで)"
+        .sell-main__container__sell-form__name__form-group
+          %label
+            商品の説明
+            %span
+              必須
+        = f.text_area :description, placeholder: "商品の説明 (必須 1000文字以内) (色、素材、重さ、低下、注意点など) \n例) 2010年頃に1万円で購入したハリボーです。色は様々で未開封のため痛んではいませんが消費期限は過ぎています。新たな世界の扉を開きたい方におすすめです。"
+      .sell-main__container__sell-form__detail
+        .sell-main__container__sell-form__detail__head
+          商品の詳細
+        .sell-main__container__sell-form__detail__box
+          .sell-main__container__sell-form__detail__box__form-group
+            %label
+              カテゴリー
+              %span
+                必須
+          /= f.collection_select :upload, Upload.all, :id, :name, {prompt: '---'}, class: 'form' カテゴリー機能未実装のため、コメントアウト
+          .sell-main__container__sell-form__detail__box__form-group
+            %label
+              サイズ
+          = f.select :size, Product.sizes.keys, {prompt: '---'}, class: 'form'
+          .sell-main__container__sell-form__detail__box__form-group
+            %label
+              商品の状態
+              %span
+                必須
+          = f.select :condition, Product.conditions.keys, {prompt: '---'}, class: 'form'
+      .sell-main__container__sell-form__delivery
+        .sell-main__container__sell-form__delivery__head
+          配送について
+          = link_to "?", class: "question"
+        .sell-main__container__sell-form__delivery__box
+          .sell-main__container__sell-form__delivery__box__form-group
+            %label
+              配送料の負担
+              %span
+                必須
+          = f.select :delivery_charge, Product.delivery_charges.keys, {prompt: '---'}, class: 'form'
+          .sell-main__container__sell-form__delivery__box__form-group
+            %label
+              配送の方法
+              %span
+                必須
+          = f.select :delivery_way, Product.delivery_ways.keys, {prompt: '---'}, class: 'form'
+          .sell-main__container__sell-form__delivery__box__form-group
+            %label
+              発送元の地域
+              %span
+                必須
+          = f.collection_select :prefecture_id, Prefecture.all, :id, :name, {prompt: '---'}, class: 'form'
+          .sell-main__container__sell-form__delivery__box__form-group
+            %label
+              発送までの日数
+              %span
+                必須
+          = f.select :delivery_days, Product.delivery_days.keys, {prompt: '---'}, class: 'form'
+      .sell-main__container__sell-form__price
+        .sell-main__container__sell-form__price__head
+          販売価格(300〜9,999,999)
+          = link_to "?", class: "question"
+        .sell-main__container__sell-form__price__box
+          .sell-main__container__sell-form__price__box__form-group
+            .sell-main__container__sell-form__price__box__form-group__left
+              %label
+                価格
+                %span
+                  必須
+            .sell-main__container__sell-form__price__box__form-group__right
+              %p
+                ¥
+                %div
+                  = f.text_field :price, placeholder: '例) 300'
+          .sell-main__container__sell-form__price__box__commission
+            .sell-main__container__sell-form__price__box__commission__left
+              販売手数料 (10%)
+            .sell-main__container__sell-form__price__box__commission__right
+              -
+          .sell-main__container__sell-form__price__box__profit
+            .sell-main__container__sell-form__price__box__profit__left
+              販売利益
+            .sell-main__container__sell-form__price__box__profit__right
+              -
+      .sell-main__container__sell-form__btn-box
+        .sell-main__container__sell-form__btn-box__text
+          %div
+            %p
+              = link_to '禁止されている出品', '#'
+              = link_to '行為', '#'
+              を必ずご確認ください。
+            %p
+              またブランド品でシリアルナンバー等がある場合はご記載ください。
+              = link_to '偽ブランドの販売', '#'
+              は犯罪であり処罰される可能性があります。
+            %p
+              また、出品をもちまして
+              = link_to '加盟店規約', '#'
+              に同意したことになります。
+        .sell-main__container__sell-form__btn-box__exhibit-btn
+          = f.submit "変更する", class: "submit-btn"
+        .sell-main__container__sell-form__btn-box__back
+          = link_to root_path do
+            キャンセル
 = render partial: 'sell_upload_footer'

--- a/app/views/products/edit.html.haml
+++ b/app/views/products/edit.html.haml
@@ -1,0 +1,3 @@
+= render partial: 'sell_upload_header'
+= render partial: 'sell_upload_main'
+= render partial: 'sell_upload_footer'

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -79,7 +79,7 @@
       .product-action
         - if user_signed_in?
           - if @product.user_id == current_user.id
-            = link_to edit_product_path(product.id), class: "link-none" do
+            = link_to edit_product_path(@product), class: "link-none" do
               .product-action__btn
                 %p.product-action__btn--edit
                   商品の編集

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -79,7 +79,7 @@
       .product-action
         - if user_signed_in?
           - if @product.user_id == current_user.id
-            = link_to "=", class: "link-none" do
+            = link_to edit_product_path(product.id), class: "link-none" do
               .product-action__btn
                 %p.product-action__btn--edit
                   商品の編集


### PR DESCRIPTION
## What
商品出品機能のビューとサーバーサイドの実装を行う。

## Why
出品者が商品の情報を編集できるようにするため。

1,実装について
products_controller.rb
・editアクションを追加
・updateアクションを追加
・@product = Product.find(params[:id]) を、set_productとしてprivateに設定。
　before_actionにて、edit、update、showの３アクションで使用するように記述。

変更点
edit.html.haml
・newと共通で使う予定だった、部分テンプレート、_sell_upload_main.html.hamlの記述コードを edit.html.hamlへ移植。
・削除ボタンをビュー内に直接記述。

new_product.js
・編集画面で使用する画像の削除ボタンのコードを、画像新規投稿で使用する削除のコードと切り離し再設定。