### PR TITLE
商品削除機能

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -24,7 +24,7 @@ class ProductsController < ApplicationController
 
   def destroy
     @product = Product.find(params[:id])
-      if product.destroy
+      if @product.destroy
         redirect_to root_path
       else
         redirect_to product_path

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -22,6 +22,15 @@ class ProductsController < ApplicationController
     @product = Product.find(params[:id])
   end
 
+  def destroy
+    @product = Product.find(params[:id])
+      if product.destroy
+        redirect_to root_path
+      else
+        redirect_to product_path
+      end
+  end
+
   private
 
   def product_params

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,5 +1,7 @@
 class ProductsController < ApplicationController
 
+  before_action :set_product, only:[:show, :destroy]
+
   def index
     @products = Product.includes(:product_images).order("created_at DESC").limit(10)
   end
@@ -19,21 +21,23 @@ class ProductsController < ApplicationController
   end
 
   def show
-    @product = Product.find(params[:id])
   end
 
   def destroy
-    @product = Product.find(params[:id])
-      if @product.destroy
-        redirect_to root_path
-      else
-        redirect_to product_path
-      end
+    if @product.destroy
+      redirect_to root_path
+    else
+      redirect_to product_path
+    end
   end
 
   private
 
   def product_params
     params.require(:product).permit(:name, :description, :size, :condition, :delivery_charge, :delivery_way, :prefecture_id, :delivery_days, :price, :status, product_images_attributes: [:image]).merge(user_id: current_user.id)
+  end
+
+  def set_product
+    @product = Product.find(params[:id])
   end
 end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -2,7 +2,7 @@ class Product < ApplicationRecord
   extend ActiveHash::Associations::ActiveRecordExtensions
     belongs_to_active_hash :prefecture
 
-    has_many :product_images
+    has_many :product_images, deprndent: :destroy
     accepts_nested_attributes_for :product_images, allow_destroy: true
     belongs_to :user
 

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -2,7 +2,7 @@ class Product < ApplicationRecord
   extend ActiveHash::Associations::ActiveRecordExtensions
     belongs_to_active_hash :prefecture
 
-    has_many :product_images, deprndent: :destroy
+    has_many :product_images, dependent: :destroy
     accepts_nested_attributes_for :product_images, allow_destroy: true
     belongs_to :user
 

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -89,8 +89,9 @@
               %p.product-action__btn--cancel
                 出品を一時停止する
             .product-action__btn
-              %p.product-action__btn--delete
-                この商品を削除する
+              = link_to product_path(@product), class: "link-none", method: :delete do
+                %p.product-action__btn--delete
+                  この商品を削除する
           - else
             -if @product.status == "出品中"
               = link_to "#", class: "link-none" do


### PR DESCRIPTION
### What
・商品の削除機能を実装する。

### Why
・出品者が商品を自由に削除できるようにするため。

実装について
product.rb
・product_imagesのアソシエーションに、関連要素の削除に関するメソッドを追加。

products_controller.rb
・destroyアクションを追加。
※商品編集で追加したbefore_actionに統合予定の記述あり。

show.html.haml
・商品削除のボタンに、link_toでdeleteメソッドを追加。