### PR TITLE
ユーザー本人確認ページ

### DIFF
--- a/app/assets/stylesheets/_breadcrumbs.scss
+++ b/app/assets/stylesheets/_breadcrumbs.scss
@@ -1,7 +1,7 @@
 .breadcrumbs {
   height: 40px;
   width: 100%;
-  padding: 10px;
+  padding: 13px 10px 10px 130px;
   font-size: 15px;
 }
 

--- a/app/assets/stylesheets/_header.scss
+++ b/app/assets/stylesheets/_header.scss
@@ -1,7 +1,7 @@
 .header{
   height: 100px;
   width: 100%;
-  border-bottom: solid 1px;
+  border-bottom: solid 2px $basic-white;
   z-index: 2;
 }
 

--- a/app/assets/stylesheets/address.scss
+++ b/app/assets/stylesheets/address.scss
@@ -107,7 +107,7 @@ label {
   }
 }
 
-#prefecture_id {
+#address_prefecture_id {
   background-color: $progress_white;
   font-size: 16px;
   height: 50px;

--- a/app/assets/stylesheets/address.scss
+++ b/app/assets/stylesheets/address.scss
@@ -1,0 +1,122 @@
+.users {
+  background-color: white;
+  width: 700px;
+  margin: 0 0 50px 320px;
+}
+
+.users-title {
+  padding: 25px;
+  font-size: 25px;
+  border-bottom: solid 4px $basic-white;
+
+  &__text {
+    margin-left: 240px;
+    font-weight: bold;
+  }
+}
+
+label {
+  font-size: 14px;
+  font-weight: bold;
+}
+
+.users-info {
+  padding: 50px;
+
+  &__attention {
+    padding:25px;
+    margin-bottom: 20px;
+
+    &--link {
+      margin-top: 10px;
+      float: right;
+    }
+  }
+
+  &__detaile {
+    margin-bottom: 40px;
+
+    &__name {
+
+      &--full {
+        margin: 5px 0 30px 0;
+      }
+    }
+
+    &__kana {
+
+      &--full {
+        margin: 5px 0 30px 0;
+      }
+    }
+
+    &__birth {
+
+      &--num {
+        margin-top: 5px;
+      }
+    }
+  }
+
+  &__address {
+    
+    &__btn {
+
+      &--change {
+        width: 600px;
+        height: 50px;
+        font-size: 14px;
+        background-color: $progress_red;
+        text-align: center;
+        align-items: center;
+        color: $progress_white;
+        cursor: pointer;
+        margin-bottom: 20px;
+      }
+    }
+
+    &--link {
+      float: right;
+      margin-top: 10px;
+    }
+  }
+}
+
+.any-tag {
+  height: 30px;
+  width: 40px;
+  text-align: center;
+  padding-top: 7px;
+  background-color: #ccc;
+  color: white;
+  border-radius: 3px;
+  position: relative;
+  top: -20px;
+  left: 70px;
+}
+
+.address-form {
+  
+  &__input {
+    font-size: 16px;
+    border: solid 1px #ccc;
+    padding: 10px;
+    width: 600px;
+    border-radius: 5px;
+    margin: -20px 0 20px 0;
+  }
+}
+
+#prefecture_id {
+  background-color: $progress_white;
+  font-size: 16px;
+  height: 50px;
+  border: solid 1px #ccc;
+  padding: 10px;
+  width: 600px;
+  border-radius: 5px;
+  margin: -20px 0 20px 0;
+  -webkit-appearance: none;
+  appearance: none;
+  cursor: pointer;
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -19,6 +19,7 @@
 @import "./mypage";
 @import "./breadcrumbs";
 @import "./purchase";
+@import "./address";
 
 * {
   box-sizing: border-box;

--- a/app/controllers/addresses_controller.rb
+++ b/app/controllers/addresses_controller.rb
@@ -1,14 +1,23 @@
 class AddressesController < ApplicationController
-    
-  # def new
-  #   @address = Address.new
-  #   @user = User.new
-  # end
+  before_action :authenticate_user!
 
-  # def create
-  #   @address = Address.new(address_params)
-  #   if @address.save
-  #   redirect_to controller: '/registrations', action: 'new_payment'
-  #   end
-  # end
+  def edit
+    @user = current_user
+    @address = Addresses.find_by(user_id: current_user.id)
+  end
+
+  def update
+    @address = Address.find_by(user_id: current_user.id)
+    if @address.update(set_address)
+      redirect_to address_mypages_path
+    else
+      render :edit
+    end
+  end
+
+  private
+    def set_address
+      params.permit(:zip_code, :prefecture_id, :city, :block, :building_name).merge(user_id: current_user.id)
+    end
+
 end

--- a/app/controllers/addresses_controller.rb
+++ b/app/controllers/addresses_controller.rb
@@ -1,15 +1,14 @@
 class AddressesController < ApplicationController
   before_action :authenticate_user!
+  before_action :find_address, only:[:edit, :update]
 
   def edit
     @user = current_user
-    @address = Addresses.find_by(user_id: current_user.id)
   end
 
   def update
-    @address = Address.find_by(user_id: current_user.id)
     if @address.update(set_address)
-      redirect_to address_mypages_path
+      redirect_to mypages_path
     else
       render :edit
     end
@@ -17,7 +16,11 @@ class AddressesController < ApplicationController
 
   private
     def set_address
-      params.permit(:zip_code, :prefecture_id, :city, :block, :building_name).merge(user_id: current_user.id)
+      params.require(:address).permit(:zip_code, :prefecture_id, :city, :block, :building_name).merge(user_id: current_user.id)
+    end
+
+    def find_address
+      @address = Address.find_by(user_id: current_user.id)
     end
 
 end

--- a/app/controllers/mypages_controller.rb
+++ b/app/controllers/mypages_controller.rb
@@ -8,21 +8,4 @@ class MypagesController < ApplicationController
   def profile
   end
 
-  def address
-    @user = current_user
-    @address = Address.find_by(user_id: current_user.id)
-  end
-
-  def address_update
-    if @address.update(set_address)
-      redirect_to address_mypages_path
-    else
-      render :address
-    end
-  end
-
-  private
-    def set_address
-      params.permit(:zip_code, :prefecture_id, :city, :block, :building_name).merge(user_id: current_user.id)
-    end
 end

--- a/app/controllers/mypages_controller.rb
+++ b/app/controllers/mypages_controller.rb
@@ -10,9 +10,13 @@ class MypagesController < ApplicationController
   end
 
   def address
-  #  @address = Addresses.find_by(user_id: current_user.id)
+    @user = current_user
+    @address = Address.find_by(user_id: current_user.id)
   end
 
+  def address_update
+    
+  end
 
   private
     def set_address

--- a/app/controllers/mypages_controller.rb
+++ b/app/controllers/mypages_controller.rb
@@ -1,6 +1,5 @@
 class MypagesController < ApplicationController
   before_action :authenticate_user!
-  # before_action :set_address, only:[:address]
 
   def index
     @user = current_user
@@ -15,7 +14,11 @@ class MypagesController < ApplicationController
   end
 
   def address_update
-    
+    if @address.update(set_address)
+      redirect_to address_mypages_path
+    else
+      render :address
+    end
   end
 
   private

--- a/app/controllers/mypages_controller.rb
+++ b/app/controllers/mypages_controller.rb
@@ -10,12 +10,9 @@ class MypagesController < ApplicationController
   end
 
   def address
-   # @address = Addresses.find_by(user_id: current_user.id)
+  #  @address = Addresses.find_by(user_id: current_user.id)
   end
 
-  def identification 
-    @address= Address.find_by(user_id: current_user.id)  
-  end
 
   private
     def set_address

--- a/app/controllers/mypages_controller.rb
+++ b/app/controllers/mypages_controller.rb
@@ -1,5 +1,6 @@
 class MypagesController < ApplicationController
   before_action :authenticate_user!
+  # before_action :set_address, only:[:address]
 
   def index
     @user = current_user
@@ -8,8 +9,16 @@ class MypagesController < ApplicationController
   def profile
   end
 
+  def address
+   # @address = Addresses.find_by(user_id: current_user.id)
+  end
+
   def identification 
     @address= Address.find_by(user_id: current_user.id)  
   end
 
+  private
+    def set_address
+      params.permit(:zip_code, :prefecture_id, :city, :block, :building_name).merge(user_id: current_user.id)
+    end
 end

--- a/app/views/addresses/edit.html.haml
+++ b/app/views/addresses/edit.html.haml
@@ -4,7 +4,7 @@
 = render "layouts/breadcrumbs"
 
 .mypage-wrapper
-  = render partial: "mypage_sidebar"
+  = render partial: "mypages/mypage_sidebar"
   
   .users
     .users-title
@@ -34,7 +34,7 @@
             = current_user.birthday
 
       .users-info__address
-      = form_with model: @address, url: address_mypages_path, mehotd: :patch, local: true do |f|
+      = form_with  model: @address, method: :patch, local: true do |f|
         .address-form
           %label.users-info__address--caption 郵便番号
           .any-tag 任意

--- a/app/views/mypages/_mypage_sidebar.html.haml
+++ b/app/views/mypages/_mypage_sidebar.html.haml
@@ -86,7 +86,7 @@
       メール/パスワード
       .mypage_sidebar__angle-right
         = fa_icon "angle-right"
-    = link_to mypage_address_mypages_path do
+    = link_to address_mypages_path do
       .mypage_sidebar-configuration__identity-information
         本人情報
         .mypage_sidebar__angle-right

--- a/app/views/mypages/_mypage_sidebar.html.haml
+++ b/app/views/mypages/_mypage_sidebar.html.haml
@@ -86,10 +86,11 @@
       メール/パスワード
       .mypage_sidebar__angle-right
         = fa_icon "angle-right"
-    .mypage_sidebar-configuration__identity-information
-      本人情報
-      .mypage_sidebar__angle-right
-        = fa_icon "angle-right"
+    = link_to mypage_address_mypages_path do
+      .mypage_sidebar-configuration__identity-information
+        本人情報
+        .mypage_sidebar__angle-right
+          = fa_icon "angle-right"
     .mypage_sidebar-configuration__confirm-phone-number
       電話番号の確認
       .mypage_sidebar__angle-right

--- a/app/views/mypages/_mypage_sidebar.html.haml
+++ b/app/views/mypages/_mypage_sidebar.html.haml
@@ -86,7 +86,7 @@
       メール/パスワード
       .mypage_sidebar__angle-right
         = fa_icon "angle-right"
-    = link_to address_mypages_path do
+    = link_to edit_address_path(current_user.id) do
       .mypage_sidebar-configuration__identity-information
         本人情報
         .mypage_sidebar__angle-right

--- a/app/views/mypages/address.html.haml
+++ b/app/views/mypages/address.html.haml
@@ -1,0 +1,64 @@
+= render partial: "products/header"
+
+- breadcrumb :address
+= render "layouts/breadcrumbs"
+
+.mypage-wrapper
+  = render partial: "mypage_sidebar"
+  
+  .users-info
+    .users-info__caption
+      .users-info__caption--title
+        本人情報の登録
+    .users-info__attention
+      .users-info__attention--text
+        お客様の本人情報をご登録ください。
+        %br
+        登録されたお名前・生年月日を変更する場合、本人確認書類の提示が必要になります。
+      .users-info__attention--link
+        = link_to "/", class: "link-color" do
+          本人確認書類のアップロードについて ＞
+    .users-info__detaile
+      .users-info__detaile__name
+        %label お名前
+        .users-info__detaile__name--full
+          makura
+          -# = @user.name
+      .users-info__detaile__kana
+        %label お名前カナ
+        .users-info__detaile__kana--full
+          マクラ
+      .users-info__detaile__birth
+        %label 生年月日
+        .users-info__detaile__birth--num
+          1988/3/8
+
+    .users-info__address
+    = form_with model: @address, local: true do |f|
+      .address-form
+        %label.users-info__address--zip 郵便番号
+        %span.any-tag 任意
+        %br
+        = f.text_field :zip_code, class: "address-form__input", placeholder: "例）123-0123"
+      .addres-form
+        %label.users-info__address--prefecture 都道府県
+        %span.any-tag 任意
+        %br
+        = f.collection_select :prefecture_id, Prefecture.all, :id, :name, prompt: "--"
+      .address-form
+        %label.users-info__address--city 市区町村
+        %span.any-tag 任意
+        %br
+        = f.text_field :city, class: "address-form__input", placeholder: "例）青山1-2-3"
+      .address-form
+        %label.users-info__address--building_name
+        %span.any-tag 任意
+        %br
+        = f.text_field :building_name, class: "address-form_input", placeholder: "例）コタコマビル103" 
+      .users-info__address__btn
+        = f.submit "変更する", class: "users-info__address__btn--change"
+      .user-info__address--link
+        = link_to "/", class: "link-color" do
+          本人情報の登録について ＞
+
+= render partial: "products/footer"

--- a/app/views/mypages/address.html.haml
+++ b/app/views/mypages/address.html.haml
@@ -23,18 +23,18 @@
         .users-info__detaile__name
           %label お名前
           .users-info__detaile__name--full
-            = @user.name
+            = current_user.last_name + current_user.first_name
         .users-info__detaile__kana
           %label お名前カナ
           .users-info__detaile__kana--full
-            マクラ
+            = current_user.last_name_kana + current_user.first_name_kana
         .users-info__detaile__birth
           %label 生年月日
           .users-info__detaile__birth--num
-            1988/3/8
+            = current_user.birthday
 
       .users-info__address
-      = form_with model: @address, local: true do |f|
+      = form_with model: @address, url: address_mypages_path, local: true do |f|
         .address-form
           %label.users-info__address--caption 郵便番号
           .any-tag 任意

--- a/app/views/mypages/address.html.haml
+++ b/app/views/mypages/address.html.haml
@@ -34,7 +34,7 @@
             = current_user.birthday
 
       .users-info__address
-      = form_with model: @address, url: address_mypages_path, local: true do |f|
+      = form_with model: @address, url: address_mypages_path, mehotd: :patch, local: true do |f|
         .address-form
           %label.users-info__address--caption 郵便番号
           .any-tag 任意

--- a/app/views/mypages/address.html.haml
+++ b/app/views/mypages/address.html.haml
@@ -6,59 +6,65 @@
 .mypage-wrapper
   = render partial: "mypage_sidebar"
   
-  .users-info
-    .users-info__caption
-      .users-info__caption--title
+  .users
+    .users-title
+      .users-title__text
         本人情報の登録
-    .users-info__attention
-      .users-info__attention--text
-        お客様の本人情報をご登録ください。
-        %br
-        登録されたお名前・生年月日を変更する場合、本人確認書類の提示が必要になります。
-      .users-info__attention--link
-        = link_to "/", class: "link-color" do
-          本人確認書類のアップロードについて ＞
-    .users-info__detaile
-      .users-info__detaile__name
-        %label お名前
-        .users-info__detaile__name--full
-          makura
-          -# = @user.name
-      .users-info__detaile__kana
-        %label お名前カナ
-        .users-info__detaile__kana--full
-          マクラ
-      .users-info__detaile__birth
-        %label 生年月日
-        .users-info__detaile__birth--num
-          1988/3/8
+    .users-info      
+      .users-info__attention
+        .users-info__attention--text
+          お客様の本人情報をご登録ください。
+          %br
+          登録されたお名前・生年月日を変更する場合、本人確認書類の提示が必要になります。
+        .users-info__attention--link
+          = link_to "/", class: "link-color" do
+            本人確認書類のアップロードについて ＞
+      .users-info__detaile
+        .users-info__detaile__name
+          %label お名前
+          .users-info__detaile__name--full
+            makura
+            -# = @user.name
+        .users-info__detaile__kana
+          %label お名前カナ
+          .users-info__detaile__kana--full
+            マクラ
+        .users-info__detaile__birth
+          %label 生年月日
+          .users-info__detaile__birth--num
+            1988/3/8
 
-    .users-info__address
-    = form_with model: @address, local: true do |f|
-      .address-form
-        %label.users-info__address--zip 郵便番号
-        %span.any-tag 任意
-        %br
-        = f.text_field :zip_code, class: "address-form__input", placeholder: "例）123-0123"
-      .addres-form
-        %label.users-info__address--prefecture 都道府県
-        %span.any-tag 任意
-        %br
-        = f.collection_select :prefecture_id, Prefecture.all, :id, :name, prompt: "--"
-      .address-form
-        %label.users-info__address--city 市区町村
-        %span.any-tag 任意
-        %br
-        = f.text_field :city, class: "address-form__input", placeholder: "例）青山1-2-3"
-      .address-form
-        %label.users-info__address--building_name
-        %span.any-tag 任意
-        %br
-        = f.text_field :building_name, class: "address-form_input", placeholder: "例）コタコマビル103" 
-      .users-info__address__btn
-        = f.submit "変更する", class: "users-info__address__btn--change"
-      .user-info__address--link
-        = link_to "/", class: "link-color" do
-          本人情報の登録について ＞
+      .users-info__address
+      = form_with model: @address, local: true do |f|
+        .address-form
+          %label.users-info__address--caption 郵便番号
+          .any-tag 任意
+          %br
+          = f.text_field :zip_code, class: "address-form__input", placeholder: "例）123-0123"
+        .addres-form
+          %label.users-info__address--caption 都道府県
+          .any-tag 任意
+          %br
+          = f.collection_select :prefecture_id, Prefecture.all, :id, :name, prompt: "--", class: "address-form__prefecture"
+        .address-form
+          %label.users-info__address--caption 市区町村
+          .any-tag 任意
+          %br
+          = f.text_field :city, class: "address-form__input", placeholder: "例）東京都調布市"
+        .address-form
+          %label.users-info__address--caption 番地
+          .any-tag 任意
+          %br
+          = f.text_field :block, class: "address-form__input", placeholder: "例）青山1-2-3" 
+        .address-form
+          %label.users-info__address--caption 建物名
+          .any-tag 任意
+          %br
+          = f.text_field :building_name, class: "address-form__input", placeholder: "例）コタコマビル103" 
+        .users-info__address__btn
+          = f.submit "変更する", class: "users-info__address__btn--change"
+        .users-info__address--link
+          = link_to "/", class: "link-color" do
+            本人情報の登録について ＞
 
 = render partial: "products/footer"

--- a/app/views/mypages/address.html.haml
+++ b/app/views/mypages/address.html.haml
@@ -23,8 +23,7 @@
         .users-info__detaile__name
           %label お名前
           .users-info__detaile__name--full
-            makura
-            -# = @user.name
+            = @user.name
         .users-info__detaile__kana
           %label お名前カナ
           .users-info__detaile__kana--full

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -18,7 +18,7 @@ crumb :logout do
 end
 
 crumb :address do
-  link "本人情報の確認", mypage_address_mypages_path
+  link "本人情報の確認", address_mypages_path
   parent :mypage
 end
 

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -17,6 +17,11 @@ crumb :logout do
   parent :mypage
 end
 
+crumb :address do
+  link "本人情報の確認", mypage_address_mypages_path
+  parent :mypage
+end
+
 # crumb :projects do
 #   link "Projects", projects_path
 # end

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -18,7 +18,7 @@ crumb :logout do
 end
 
 crumb :address do
-  link "本人情報の確認", address_mypages_path
+  link "本人情報の確認", edit_address_path
   parent :mypage
 end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,14 +32,14 @@ Rails.application.routes.draw do
   end
 
   resources :logouts, only: [:index]
-  resources :mypages,only: [:index] do
+  resources :mypages,only: [:index, :address_update] do
     collection do
       get '/mypage/identification', to: 'mypages#identification'
       get '/mypage/profile', to: 'mypages#profile'
       get '/mypage/card', to: 'mypages#card'
       get '/mypage/card/new', to: 'mypages#card_new'
       get '/address', to: 'mypages#address'
-      
+      patch '/address_update', to: 'mypages#address'
     end
   end
   resources :payments do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,8 +42,7 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :addresses, only: [:edit, :update] do
-  end
+  resources :addresses, only: [:edit, :update]
   
   resources :payments do
     collection do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,7 +39,7 @@ Rails.application.routes.draw do
       get '/mypage/card', to: 'mypages#card'
       get '/mypage/card/new', to: 'mypages#card_new'
       get '/address', to: 'mypages#address'
-    
+      
     end
   end
   resources :payments do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,16 +32,18 @@ Rails.application.routes.draw do
   end
 
   resources :logouts, only: [:index]
-  resources :mypages,only: [:index, :address_update] do
+  resources :mypages,only: [:index, :update] do
     collection do
       get '/mypage/identification', to: 'mypages#identification'
       get '/mypage/profile', to: 'mypages#profile'
       get '/mypage/card', to: 'mypages#card'
       get '/mypage/card/new', to: 'mypages#card_new'
-      get '/address', to: 'mypages#address'
-      patch '/address_update', to: 'mypages#address'
     end
   end
+
+  resources :addresses, only: [:edit, :update] do
+  end
+  
   resources :payments do
     collection do
       post 'show', to: 'payments#show'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,6 +38,7 @@ Rails.application.routes.draw do
       get '/mypage/profile', to: 'mypages#profile'
       get '/mypage/card', to: 'mypages#card'
       get '/mypage/card/new', to: 'mypages#card_new'
+      get '/mypage/address/', to: 'mypages#address'
     end
   end
   resources :payments do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,7 +38,8 @@ Rails.application.routes.draw do
       get '/mypage/profile', to: 'mypages#profile'
       get '/mypage/card', to: 'mypages#card'
       get '/mypage/card/new', to: 'mypages#card_new'
-      get '/mypage/address/', to: 'mypages#address'
+      get '/address', to: 'mypages#address'
+    
     end
   end
   resources :payments do


### PR DESCRIPTION
### What
ユーザーの本人確認ページを作成する。

### Why
ユーザーが本人自身の情報の確認・編集を行ってもらうため。

・実装について
1,ルートをaddressで設定。editとupdateのpathを作成。

2,addresses_controller.rbにeditとupdateアクションを設定。
　privateにset_addressとfind_addressを設定。
　before_actionにauthenticate_user!とfind_addressを設定。

3,views/addressesにedit.html.hamlを作成。内容記述。

4,stylesheetsにaddresses.scssを作成。内容記述。

5,パンくず機能の追加とマイページのサイドバーにlink_toでeditへのpathを記述。

6,ヘッダーとパンくずのcss調整
